### PR TITLE
ouvre 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouvre",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Open web pages configured in a config file to be more efficient.",
   "main": "ouvre.sh",
   "scripts": {
@@ -71,6 +71,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.